### PR TITLE
#159 add contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,9 +17,9 @@ All contributions are encouraged and valued. Please read the [Table of Contents]
 
 This project and everyone participating in it is governed by the [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to the project maintainers.
 
-## How to Contribute
+## Issues
 
-### Reporting Issues
+Please raise bug reports and feature requests as Issues on [the GitHub project](https://github.com/G-Research/NuGetPackageChecker/issues).
 
 If you find a bug or a potential issue:
 
@@ -32,20 +32,18 @@ If you find a bug or a potential issue:
    - Relevant logs, error messages, or screenshots.
    - Your environment details (OS, .NET version, NuGet version, etc.).
 
-### Suggesting Enhancements
+## Pull Requests
 
-To propose a new feature or improvement:
+Before embarking on a large change, we strongly recommend checking via a GitHub Issue first to confirm whether we are likely to accept it.
 
-1. Review the [existing discussions and issues](https://github.com/G-Research/NuGetPackageChecker/issues) to check if the idea has been discussed.
-2. If not, [open a feature request](https://github.com/G-Research/NuGetPackageChecker/issues/new?labels=enhancement) and include:
-   - A clear and descriptive title.
-   - The problem your suggestion solves.
-   - Any potential alternatives or workarounds.
-   - Why this enhancement would be beneficial.
+You may find that the following guidelines will help you produce a change that we accept:
+
+* Keep your change as small and focused as practical.
+* Ensure that your change is thoroughly tested.
+* Document any choices you make that are not immediately obvious.
+* Explain why your change is necessary or desirable.
 
 ### Submitting a Pull Request
-
-> **Legal Notice:** By contributing to this project, you agree that you have authored 100% of the content, have the necessary rights to it, and that your contributions may be provided under the project's license.
 
 #### Steps to Submit a PR
 
@@ -93,5 +91,5 @@ Want to be more involved?
 - Share your experience using NuGetPackageChecker.
 - Contact the maintainers to discuss the project.
 
-Thank you for helping make this project better! 
+Thank you for helping make this project better!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,7 @@ Want to be more involved?
 - Help review and triage issues.
 - Assist new contributors by answering questions.
 - Share your experience using NuGetPackageChecker.
+- Contact the maintainers to discuss the project.
 
 Thank you for helping make this project better! 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to NuGetPackageChecker
 
-All contributions are encouraged and valued. Please read the [Table of Contents](#table-of-contents) before contributing to help maintainers and improve the experience for everyone. The community looks forward to your contributions.
+All contributions are encouraged and valued. Please read the [Code of Conduct](#code-of-conduct) in addition   to this contributing guide to help maintainers and improve the experience for everyone. The community looks forward to your contributions.
 
 ## Table of Contents
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,6 @@
 # Contributing to NuGetPackageChecker
 
-All types of contributions are encouraged and valued. See the [Table of Contents](#table-of-contents) for different ways to help and details about how this project handles them. Please make sure to read the relevant section before making your contribution. It will make it a lot easier for us maintainers and smooth out the experience for all involved. The community looks forward to your contributions.
-
-> And if you like the project but just don't have time to contribute, that's fine. There are other easy ways to support the project and show your appreciation:
-> - Star the project
-> - Tweet about it
-> - Mention it in your project's README
-> - Share it with your colleagues or in local meetups
+All contributions are encouraged and valued. Please read the [Table of Contents](#table-of-contents) before contributing to help maintainers and improve the experience for everyone. The community looks forward to your contributions.
 
 ## Table of Contents
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,10 +5,8 @@ All contributions are encouraged and valued. Please read the [Table of Contents]
 ## Table of Contents
 
 - [Code of Conduct](#code-of-conduct)
-- [How to Contribute](#how-to-contribute)
-  - [Reporting Issues](#reporting-issues)
-  - [Suggesting Enhancements](#suggesting-enhancements)
-  - [Submitting a Pull Request](#submitting-a-pull-request)
+- [Issues](#issues)
+- [Pull Requests](#pull-requests)
 - [Coding Guidelines](#coding-guidelines)
 - [Commit Messages](#commit-messages)
 - [Community Involvement](#community-involvement)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,102 @@
+# Contributing to NuGetPackageChecker
+
+All types of contributions are encouraged and valued. See the [Table of Contents](#table-of-contents) for different ways to help and details about how this project handles them. Please make sure to read the relevant section before making your contribution. It will make it a lot easier for us maintainers and smooth out the experience for all involved. The community looks forward to your contributions.
+
+> And if you like the project but just don't have time to contribute, that's fine. There are other easy ways to support the project and show your appreciation:
+> - Star the project
+> - Tweet about it
+> - Mention it in your project's README
+> - Share it with your colleagues or in local meetups
+
+## Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [How to Contribute](#how-to-contribute)
+  - [Reporting Issues](#reporting-issues)
+  - [Suggesting Enhancements](#suggesting-enhancements)
+  - [Submitting a Pull Request](#submitting-a-pull-request)
+- [Coding Guidelines](#coding-guidelines)
+- [Commit Messages](#commit-messages)
+- [Community Involvement](#community-involvement)
+
+## Code of Conduct
+
+This project and everyone participating in it is governed by the [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to the project maintainers.
+
+## How to Contribute
+
+### Reporting Issues
+
+If you find a bug or a potential issue:
+
+1. Make sure you are using the latest version of the package.
+2. Check the existing [Issues](https://github.com/G-Research/NuGetPackageChecker/issues) to see if it has already been reported.
+3. If no existing issue matches, [open a new issue](https://github.com/G-Research/NuGetPackageChecker/issues/new) and provide:
+   - A clear and descriptive title.
+   - Steps to reproduce the issue.
+   - Expected vs actual behavior.
+   - Relevant logs, error messages, or screenshots.
+   - Your environment details (OS, .NET version, NuGet version, etc.).
+
+### Suggesting Enhancements
+
+To propose a new feature or improvement:
+
+1. Review the [existing discussions and issues](https://github.com/G-Research/NuGetPackageChecker/issues) to check if the idea has been discussed.
+2. If not, [open a feature request](https://github.com/G-Research/NuGetPackageChecker/issues/new?labels=enhancement) and include:
+   - A clear and descriptive title.
+   - The problem your suggestion solves.
+   - Any potential alternatives or workarounds.
+   - Why this enhancement would be beneficial.
+
+### Submitting a Pull Request
+
+> **Legal Notice:** By contributing to this project, you agree that you have authored 100% of the content, have the necessary rights to it, and that your contributions may be provided under the project's license.
+
+#### Steps to Submit a PR
+
+1. Fork the repository and create a new branch from `main`.
+2. Implement your changes, following the [Coding Guidelines](#coding-guidelines).
+3. Ensure your changes pass all tests.
+4. Commit your changes with a meaningful commit message (see [Commit Messages](#commit-messages)).
+5. Push your branch and open a pull request.
+6. The maintainers will review your PR and provide feedback.
+
+## Coding Guidelines
+
+- Follow the existing coding style and project conventions.
+- Keep changes focused; avoid unrelated modifications.
+- Ensure all tests pass before submitting a PR.
+- Write descriptive commit messages.
+- Keep PRs small and easy to review.
+
+## Commit Messages
+
+A good commit message should:
+
+- Start with a concise summary in **50 characters or less**.
+- Provide additional details in the body if necessary.
+- Reference relevant issues using `Fixes #issue-number` when applicable.
+- Use imperative language (e.g., "Add support for XYZ" instead of "Added support for XYZ").
+
+Example:
+
+```
+Fix validation error handling in package checker
+
+- Improve error reporting for missing package versions
+- Add unit tests for version validation logic
+
+Fixes #42
+```
+
+## Community Involvement
+
+Want to be more involved?
+
+- Help review and triage issues.
+- Assist new contributors by answering questions.
+- Share your experience using NuGetPackageChecker.
+
+Thank you for helping make this project better! 
+


### PR DESCRIPTION
# Added contributing guidelines

Wrote down the CONTRIBUTING.md file to improve the contribution experience for new users.

## Commit explanation
The first commit adds the contributing file for the project

The second commit updated the contact suggestion section for communication with other contributors (adding a contact email would be great)

 The third commit modifies minor issues with the file.

Done @tabathad !